### PR TITLE
GetComponent() Retornando ponteiro e unsigned ints nos loops de tilemap

### DIFF
--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -51,7 +51,7 @@ namespace RattletrapEngine {
 				
 				Se não existir um componente do tipo informado Error() será chamado
 			*/
-			Component& GetComponent(int componentType) const;
+            Component* GetComponent(int componentType) const;
 			/**
 				\brief Obtém componentes
 				\param type tipo do componente a ser buscado.

--- a/include/TileMap.h
+++ b/include/TileMap.h
@@ -65,8 +65,8 @@ namespace RattletrapEngine {
 			inline Vec2 GetVec2Coord(int pos);
 			void SetLayerVisibility(int layer, bool visibility);
 			bool IsLayerVisible(int layer);
-			Vec2 GetTileSize(void);
-		private:
+            Vec2 GetTileSize(void);
+        private:
 			int mapWidth;
 			int mapHeight;
 			int mapDepth;
@@ -94,7 +94,7 @@ namespace RattletrapEngine {
 	#include "Camera.h"
 
 namespace RattletrapEngine {
-	
+
 	template<class T>
 	void TileMap<T>::Load(std::string const &file) {
 		FILE *arq = fopen(file.c_str(), "r");
@@ -272,7 +272,7 @@ namespace RattletrapEngine {
 	T* TileMap<T>::FindNearest(Vec2 origin, Finder<T> &finder, float range) const{
 		T* chosen= nullptr;
 		float chosenTillNow= range;
-		for(int i=0; i < tileMatrix.size();i++){
+        for(int i=0; i < tileMatrix.size();i++){
 			float tempRes= finder(tileMatrix[i]);
 			if(tempRes < chosenTillNow){
 				chosen= (T*)&(tileMatrix[i]);
@@ -285,7 +285,7 @@ namespace RattletrapEngine {
 	template<class T>
 	std::vector<T*>* TileMap<T>::FindNearests(Vec2 origin, Finder<T> &finder, float range) const{
 		std::vector<T*> *chosen= new std::vector<T*>();
-		for(int i=0; i < tileMatrix.size();i++){
+        for(int i=0; i < tileMatrix.size();i++){
 			if(finder(tileMatrix[i]) < range){
 				chosen->push_back((T*) &(tileMatrix[i]) );
 			}

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -28,8 +28,8 @@ namespace RattletrapEngine {
 			Vec2 mousePos = INPUT_MANAGER.GetMousePos();
 			bool mouseIsInside = mousePos.IsInRect( associated.box );
 			if( !mouseIsInside && interactOnBoundingBox ) {
-				RectTransform& rect = dynamic_cast<RectTransform&>( associated.GetComponent( ComponentType::RECT_TRANSFORM ) );
-				mouseIsInside = mousePos.IsInRect( rect.GetBoundingBox() );
+                RectTransform* rect = dynamic_cast<RectTransform*>( associated.GetComponent( ComponentType::RECT_TRANSFORM ) );
+                mouseIsInside = mousePos.IsInRect( rect->GetBoundingBox() );
 			}
 			if( mouseIsInside ) {
 				if( INPUT_MANAGER.IsMouseDown( LEFT_MOUSE_BUTTON ) ) {

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -99,6 +99,7 @@ namespace RattletrapEngine {
                 return components[i];
 			}
 		}
+        return(nullptr);
 	}
 
 	std::vector<Component *> GameObject::GetComponents(int componentType) const{

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -93,13 +93,12 @@ namespace RattletrapEngine {
 		}
 	}
 
-	Component& GameObject::GetComponent(int componentType) const{
+    Component* GameObject::GetComponent(int componentType) const{
 		for(uint i = 0; i < components.size();i++){
 			if(components[i]->Is(componentType)){
-				return *(components[i]);
+                return components[i];
 			}
 		}
-		Error("Component not found!");
 	}
 
 	std::vector<Component *> GameObject::GetComponents(int componentType) const{

--- a/src/Grouper.cpp
+++ b/src/Grouper.cpp
@@ -54,8 +54,8 @@ namespace RattletrapEngine {
 				for( int i = 0; i < numCols; i++, x+=delta.x+pad.x ) {
 					index = i+j*numCols;
 					if(index >= n) return;
-					RectTransform& rt = dynamic_cast<RectTransform&>( groupedElements[index]->GetComponent( ComponentType::RECT_TRANSFORM ) );
-					rt.SetAnchors( {x, y},
+                    RectTransform* rt = dynamic_cast<RectTransform*>( groupedElements[index]->GetComponent( ComponentType::RECT_TRANSFORM ) );
+                    rt->SetAnchors( {x, y},
 								{x+delta.x, y+delta.y} );
 				}
 			}

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -123,7 +123,7 @@ namespace RattletrapEngine {
 		int h = 0;
 		SDL_QueryTexture( texture, nullptr, nullptr, &w, &h );
 		fontDimensions = Vec2( w, h );
-		dynamic_cast<RectTransform&>( associated.GetComponent( ComponentType::RECT_TRANSFORM ) ).SetKernelSize( fontDimensions );
+        dynamic_cast<RectTransform*>( associated.GetComponent( ComponentType::RECT_TRANSFORM ) )->SetKernelSize( fontDimensions );
 	}
 
 }


### PR DESCRIPTION
No tilemap existia comparação de unsigneds com signed ints. Era preciso saber se um dado tipo de componente existia dentro dos componentes de um GO sem quebrar a execução do programa.Uma maneira simples de fazer isso era retornar nullptr quando o component do tipo passado não for encontrado.Portanto mudou-se o retorno para ponteiro.