### PR TITLE
bugfix/textTextureCrashOnCopy

### DIFF
--- a/include/Text.h
+++ b/include/Text.h
@@ -80,7 +80,7 @@ namespace RattletrapEngine {
 		private:
 			void RemakeTexture(void);
 			std::shared_ptr<TTF_Font> font;
-			SDL_Texture* texture;
+			std::shared_ptr<SDL_Texture> texture;
 			std::string text;
 			TextStyle style;
 			int fontSize;


### PR DESCRIPTION
Agora o texture do Text é gerenciado por um smart pointer, para evir que cópias causem o problema de referência pendente. Pois como esta antes o seguinte código é capaz de causar referência pendente:

```
Text T(args);
Text C;
C = T;
return T;
```

Esse problema foi identificado muuuuito tempo atrás pelo Mock.